### PR TITLE
Simplify deploy workflow variables

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -16,6 +16,7 @@ ENV PATH=/usr/jekyll/bin:/usr/local/bundle/bin:/usr/local/sbin:/usr/local/bin:/u
 ENV VERBOSE=false
 ENV FORCE_POLLING=false
 ENV DRAFTS=false
+ENV GIT_DEPLOY_DIR="${JEKYLL_DATA_DIR}/_site"
 
 RUN apt-get clean && \
     apt-get update && \

--- a/.github/workflows/docker_build_test_publish.yml
+++ b/.github/workflows/docker_build_test_publish.yml
@@ -33,7 +33,7 @@ jobs:
         username: swedbankpay
         password: "${{ secrets.GITHUB_TOKEN }}"  # you don't need to manually set this secret. GitHub does it on your behalf
         registry: docker.pkg.github.com
-        image_name: swedbankpay/jekyll-plantuml-docker/jekyll-plantuml
+        image_name: jekyll-plantuml
         image_tag: ${{ steps.version.outputs.version }}
         dockerfile: ".docker/Dockerfile"
         push_image_and_stages: docker run --tty --volume ${{ github.workspace }}/test/jekyll-plantuml:/srv/jekyll docker.pkg.github.com/swedbankpay/jekyll-plantuml-docker/jekyll-plantuml:${{ steps.version.outputs.version }} jekyll build
@@ -47,7 +47,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: "${{ secrets.DOCKERHUB_PASSWORD }}"  # you don't need to manually set this secret. GitHub does it on your behalf
-        image_name: swedbankpay/jekyll-plantuml
+        image_name: jekyll-plantuml
         image_tag: ${{ steps.version.outputs.version }}
         dockerfile: ".docker/Dockerfile"
         push_image_and_stages: docker run --tty --volume ${{ github.workspace }}/test/jekyll-plantuml:/srv/jekyll swedbankpay/jekyll-plantuml:${{ steps.version.outputs.version }} jekyll build

--- a/.github/workflows/docker_build_test_publish.yml
+++ b/.github/workflows/docker_build_test_publish.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Publish unstable Docker image to GitHub Package Registry
       if: startsWith(github.ref, 'refs/tags/') != true
-      uses: whoan/docker-build-with-cache-action@v5.10.0
+      uses: whoan/docker-build-with-cache-action@v5.3.3
       with:
         username: swedbankpay
         password: "${{ secrets.GITHUB_TOKEN }}"  # you don't need to manually set this secret. GitHub does it on your behalf
@@ -43,7 +43,7 @@ jobs:
 
     - name: Publish stable Docker image to Docker Hub
       if: startsWith(github.ref, 'refs/tags/')
-      uses: whoan/docker-build-with-cache-action@v5.10.0
+      uses: whoan/docker-build-with-cache-action@v5.3.3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: "${{ secrets.DOCKERHUB_PASSWORD }}"  # you don't need to manually set this secret. GitHub does it on your behalf

--- a/.github/workflows/docker_build_test_publish.yml
+++ b/.github/workflows/docker_build_test_publish.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Publish unstable Docker image to GitHub Package Registry
       if: startsWith(github.ref, 'refs/tags/') != true
-      uses: whoan/docker-build-with-cache-action@v5.3.3
+      uses: whoan/docker-build-with-cache-action@v5.10.0
       with:
         username: swedbankpay
         password: "${{ secrets.GITHUB_TOKEN }}"  # you don't need to manually set this secret. GitHub does it on your behalf
@@ -43,7 +43,7 @@ jobs:
 
     - name: Publish stable Docker image to Docker Hub
       if: startsWith(github.ref, 'refs/tags/')
-      uses: whoan/docker-build-with-cache-action@v5.3.3
+      uses: whoan/docker-build-with-cache-action@v5.10.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: "${{ secrets.DOCKERHUB_PASSWORD }}"  # you don't need to manually set this secret. GitHub does it on your behalf

--- a/.github/workflows/docker_build_test_publish.yml
+++ b/.github/workflows/docker_build_test_publish.yml
@@ -30,8 +30,8 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/') != true
       uses: whoan/docker-build-with-cache-action@v5.3.3
       with:
-        username: swedbankpay
-        password: "${{ secrets.GITHUB_TOKEN }}"  # you don't need to manually set this secret. GitHub does it on your behalf
+        username: ${{ github.repository_owner }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
         registry: docker.pkg.github.com
         image_name: jekyll-plantuml
         image_tag: ${{ steps.version.outputs.version }}
@@ -46,7 +46,7 @@ jobs:
       uses: whoan/docker-build-with-cache-action@v5.3.3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: "${{ secrets.DOCKERHUB_PASSWORD }}"  # you don't need to manually set this secret. GitHub does it on your behalf
+        password: "${{ secrets.DOCKERHUB_PASSWORD }}"
         image_name: jekyll-plantuml
         image_tag: ${{ steps.version.outputs.version }}
         dockerfile: ".docker/Dockerfile"


### PR DESCRIPTION
I am unsure if I should simplify the `docker run` to use `my_awesome_image` to make it easier to read, but I think I want to keep it to ensure things are working correctly.