### PR TITLE
Move JEKYLL_ENV to the start of the line

### DIFF
--- a/.docker/entrypoint
+++ b/.docker/entrypoint
@@ -19,9 +19,9 @@ if [[ "$1" == "deploy" ]]; then
   echo "Deploying..."
 
   if [ -n "$DEFAULT_CONFIG" ]; then
-    bundle exec jekyll build --config "$DEFAULT_CONFIG" JEKYLL_ENV=production --verbose
+    JEKYLL_ENV=production bundle exec jekyll build --config "$DEFAULT_CONFIG" --verbose
   else
-    bundle exec jekyll build JEKYLL_ENV=production --verbose
+    JEKYLL_ENV=production bundle exec jekyll build --verbose
   fi
   exec /usr/jekyll/bin/deploy.sh --verbose
 elif [[ "$1" == "jekyll" ]]; then

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -52,14 +52,12 @@ jobs:
       env:
         IMAGE_TAG: ${{ steps.variables.outputs.sha8 }}
         JEKYLL_DIR: ${{ github.workspace }}
-        TEST: false
       run: ./.github/workflows/docker_run_test.sh build
 
     - name: Run Docker Image (jekyll build)
       env:
         IMAGE_TAG: ${{ steps.variables.outputs.sha8 }}
         JEKYLL_DIR: ${{ github.workspace }}/.docker/jekyll-plantuml
-        TEST: false
       run: ./.github/workflows/docker_run_test.sh build
 
     - name: Generate Branch Name


### PR DESCRIPTION
Move `JEKYLL_ENV=production` to the start of the line so it's defined as an environment variable for `bundle exec jekyll build`.