### PR TITLE
Bundle update

### DIFF
--- a/.docker/entrypoint/Gemfile.lock
+++ b/.docker/entrypoint/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.1)
+    activesupport (6.0.3.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -16,7 +16,7 @@ GEM
       url
     colorator (1.1.0)
     concurrent-ruby (1.1.6)
-    diff-lcs (1.3)
+    diff-lcs (1.4.2)
     diffy (3.3.0)
     docile (1.3.2)
     docopt (0.6.1)
@@ -108,13 +108,13 @@ GEM
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    parallel (1.19.1)
+    parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.5)
-    rack (1.6.13)
+    rack (2.1.4)
     rainbow (3.0.0)
     rake (13.0.1)
     rb-fsevent (0.10.4)
@@ -145,7 +145,7 @@ GEM
       rubocop-ast (>= 0.0.3, < 1.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.0.3)
+    rubocop-ast (0.1.0)
       parser (>= 2.7.0.1)
     ruby-progressbar (1.10.1)
     safe_yaml (1.0.5)


### PR DESCRIPTION
Most importantly updating rack to version 2.1.4 to fix CVE-2020-8184.