### PR TITLE
Update default CMD from Docker

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -105,7 +105,7 @@ LABEL org.label-schema.build-date="${DATE}" \
       org.label-schema.vendor="Swedbank Pay" \
       org.label-schema.version="${VERSION}"
 
-CMD ["serve", "--livereload", "--incremental", "--force_polling", "--watch", "--host", "0.0.0.0"]
+CMD ["--help"]
 
 ENTRYPOINT ["/var/jekyll/entrypoint/sh/entrypoint.sh"]
 


### PR DESCRIPTION
The current default command does not work as we do not support all the arguments passed, might as well have the default command be printing the help message we will get but without it looking like an error.

```
jekyll    | + exec bundle exec ruby /var/jekyll/entrypoint/lib/entrypoint.rb serve --livereload --incremental --force_polling --watch --host 0.0.0.0
jekyll    |    jekyll-plantuml: Usage:
jekyll    |   swedbankpay/jekyll-plantuml:"2.0.3" [-h | --help]
jekyll    |   swedbankpay/jekyll-plantuml:"2.0.3" [--version]
jekyll    |   swedbankpay/jekyll-plantuml:"2.0.3" build [--env=env] [--log-level=level] [--verify] [--ignore-url=url ...]
jekyll    |   swedbankpay/jekyll-plantuml:"2.0.3" serve [--env=env] [--log-level=level] [--verify] [--ignore-url=url ...]
jekyll    |   swedbankpay/jekyll-plantuml:"2.0.3" deploy [--env=env] [--log-level=level] [--dry-run] [--verify] [--ignore-url=url ...]
jekyll exited with code 0
```