### PR TITLE
Bump gems

### DIFF
--- a/.docker/entrypoint/Gemfile.lock
+++ b/.docker/entrypoint/Gemfile.lock
@@ -10,11 +10,12 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
-    codecov (0.1.17)
+    codecov (0.2.0)
+      colorize
       json
       simplecov
-      url
     colorator (1.1.0)
+    colorize (0.8.1)
     concurrent-ruby (1.1.6)
     diff-lcs (1.4.4)
     diffy (3.3.0)
@@ -104,7 +105,7 @@ GEM
     mini_magick (4.10.1)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
-    multi_json (1.14.1)
+    multi_json (1.15.0)
     multipart-post (2.1.1)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
@@ -188,7 +189,6 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
-    url (0.3.2)
     yell (2.2.2)
     zeitwerk (2.3.1)
 

--- a/.docker/entrypoint/Gemfile.lock
+++ b/.docker/entrypoint/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    rubocop (0.87.1)
+    rubocop (0.88.0)
       parallel (~> 1.10)
       parser (>= 2.7.1.1)
       rainbow (>= 2.2.2, < 4.0)

--- a/.docker/entrypoint/Gemfile.lock
+++ b/.docker/entrypoint/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    rubocop (0.87.0)
+    rubocop (0.87.1)
       parallel (~> 1.10)
       parser (>= 2.7.1.1)
       rainbow (>= 2.2.2, < 4.0)


### PR DESCRIPTION
Resolves #35, #38 and #40 without downgrading rack and reintroducing CVE-2020-8161.