### PR TITLE
Bump gems

### DIFF
--- a/.docker/entrypoint/Gemfile.lock
+++ b/.docker/entrypoint/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
-    codecov (0.2.0)
+    codecov (0.2.1)
       colorize
       json
       simplecov

--- a/.docker/entrypoint/Gemfile.lock
+++ b/.docker/entrypoint/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
       ffi (~> 1.0)
     regexp_parser (1.7.1)
     rexml (3.2.4)
-    rouge (3.20.0)
+    rouge (3.21.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)


### PR DESCRIPTION
Resolves #41 and #42 without downgrading rack and reintroducing CVE-2020-8161.