### PR TITLE
DX-1586: Bump apt packages

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -28,10 +28,10 @@ RUN apt-get clean && \
     apt-get \
     --no-install-recommends \
     install -y \
-    locales=2.28-10 \
-    default-jre=2:1.11-71 \
-    graphviz=2.40.1-6+deb10u1 \
-    fontconfig=2.13.1-2 && \
+    locales=2.31-13 \
+    default-jre=2:1.11-72 \
+    graphviz=2.42.2-5 \
+    fontconfig=2.13.1-4.2 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ vendor/
 coverage/
 docker-compose.yml
 tmp/
+.vscode


### PR DESCRIPTION
Bump apt packages as [the build is currently failing](https://github.com/SwedbankPay/jekyll-plantuml-docker/pull/224/checks?check_run_id=3377641018#step:5:101) due to some package versions missing from the package repository (probably).

- Bump locales from version `2.28-10` to version `2.31-13`.
- Bump default-jre from version `2:1.11-71` to version `2:1.11-72`.
- Bump graphviz from version `2.40.1-6+deb10u1` to version `2.42.2-5`.
- Bump fontconfig from version `2.13.1-2` to version `2.13.1-4.2`.